### PR TITLE
Fix SSE streaming with node-llama-cpp

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cors": "^2.8.5",
         "express": "^5.1.0",
         "node-llama-cpp": "^3.10.0"
       }
@@ -1134,6 +1135,19 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -2251,6 +2265,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/server/package.json
+++ b/server/package.json
@@ -9,8 +9,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^5.1.0",
     "node-llama-cpp": "^3.10.0"
   }

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,17 +1,27 @@
-const express = require('express');
-const { createLLM } = require('node-llama-cpp');
-const cors = require('cors');
+import express from 'express';
+import cors from 'cors';
+import { getLlama, LlamaChatSession } from 'node-llama-cpp';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 const app = express();
 app.use(cors());
 app.use(express.json());
 
-// simple in-memory model init
-let llama;
+let session;
+let model;
+
 (async () => {
   try {
-    llama = await createLLM({
-      modelPath: process.env.LLAMA_MODEL || 'models/ggml-model.bin',
+    const llama = await getLlama();
+    model = await llama.loadModel({
+      modelPath: process.env.LLAMA_MODEL || path.join(__dirname, '../models/mistral-7b.gguf')
     });
+    const context = await model.createContext();
+    session = new LlamaChatSession({ contextSequence: context.getSequence() });
+    console.log('Model loaded');
   } catch (err) {
     console.error('Failed to init model:', err);
   }
@@ -23,18 +33,23 @@ app.post('/chat', async (req, res) => {
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
 
-  if (!llama) {
-    res.write(`data: Error: model not loaded\n\n`);
+  if (!session) {
+    res.write('data: Error: model not loaded\n\n');
+    res.write('data: [DONE]\n\n');
     return res.end();
   }
 
   try {
-    for await (const chunk of llama.createCompletionStream({ prompt: message })) {
-      res.write(`data: ${chunk}\n\n`);
-    }
+    await session.prompt(message, {
+      onToken(tokens) {
+        const text = model.detokenize(tokens);
+        res.write('data: ' + text + '\n\n');
+      }
+    });
   } catch (err) {
-    res.write(`data: Error: ${err.message}\n\n`);
+    res.write('data: Error: ' + err.message + '\n\n');
   } finally {
+    res.write('data: [DONE]\n\n');
     res.end();
   }
 });


### PR DESCRIPTION
## Summary
- convert server to ESM and use `getLlama`
- load models from `.gguf` and stream tokens via SSE
- add `cors` dependency

## Testing
- `npm install` in `server`
- `npm start` *(fails: ENOENT no model file)*

------
https://chatgpt.com/codex/tasks/task_e_68548cf68be8832c86eafaeab4bde32b