### PR TITLE
Restored prior UI styling

### DIFF
--- a/client/src/Chat.tsx
+++ b/client/src/Chat.tsx
@@ -67,25 +67,45 @@ export default function Chat() {
   }
 
   return (
-    <div style={{display:'flex',flexDirection:'column',height:'100%'}}>
-      <div className="chat" ref={chatRef}>
-        {messages.map((m,i) => (
-          <Message key={i} role={m.role} content={m.content} />
-        ))}
-        {loading && (
-          <div className="message assistant">
-            <div className="bubble"><span className="typing">Nox is thinking<span className="blink">|</span></span></div>
-          </div>
-        )}
+    <>
+      <div id="chat-container">
+        <div id="messages" ref={chatRef}>
+          {messages.map((m, i) => (
+            <Message key={i} role={m.role} content={m.content} />
+          ))}
+          {loading && (
+            <div className="message assistant">
+              <span className="thinking">Nox is thinking</span>
+            </div>
+          )}
+        </div>
       </div>
-      <form className="input-area" onSubmit={sendMessage}>
-        <input
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          placeholder="Ask Nox..."
-        />
-        <button type="submit">Send</button>
+      <form id="input-form" onSubmit={sendMessage}>
+        <div id="input-container">
+          <input
+            id="input"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Type your message"
+            autoComplete="off"
+          />
+          <button id="send-button" type="submit" aria-label="Send">
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              xmlns="http://www.w3.org/2000/svg"
+              className="icon"
+            >
+              <path d="M8.99992 16V6.41407L5.70696 9.70704C5.31643 10.0976 4.68342 10.0976 4.29289 9.70704C3.90237 9.31652 3.90237 8.6835 4.29289 8.29298L9.29289 3.29298L9.36907 3.22462C9.76184 2.90427 10.3408 2.92686 10.707 3.29298L15.707 8.29298L15.7753 8.36915C16.0957 8.76192 16.0731 9.34092 15.707 9.70704C15.3408 10.0732 14.7618 10.0958 14.3691 9.7754L14.2929 9.70704L10.9999 6.41407V16C10.9999 16.5523 10.5522 17 9.99992 17C9.44764 17 8.99992 16.5523 8.99992 16Z" />
+            </svg>
+          </button>
+        </div>
+        <button id="stop-button" type="button" disabled>
+          Stop
+        </button>
       </form>
-    </div>
+    </>
   );
 }

--- a/client/src/Message.tsx
+++ b/client/src/Message.tsx
@@ -4,9 +4,5 @@ export interface MessageProps {
 }
 
 export default function Message({ role, content }: MessageProps) {
-  return (
-    <div className={`message ${role}`}> 
-      <div className="bubble">{content}</div>
-    </div>
-  );
+  return <div className={`message ${role}`}>{content}</div>;
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,75 +1,136 @@
 body {
+  background-color: #1e1e1e;
+  color: #e0e0e0;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
   margin: 0;
-  font-family: system-ui, sans-serif;
-  background: #f5f5f5;
-  color: #222;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+  padding: 0;
 }
 
-#root {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-}
-
-.chat {
-  flex: 1;
-  overflow-y: auto;
+#chat-container {
+  max-width: 700px;
+  margin: 0 auto;
   padding: 1rem;
+  padding-bottom: 4rem; /* space for input */
+}
+
+#messages {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .message {
-  margin-bottom: 0.5rem;
-  display: flex;
-}
-.message.user {
-  justify-content: flex-end;
-}
-.message .bubble {
-  padding: 0.5rem 0.75rem;
-  border-radius: 12px;
-  max-width: 70%;
-  line-height: 1.4;
-}
-.message.user .bubble {
-  background: #007bff;
-  color: white;
-  border-bottom-right-radius: 0;
-}
-.message.assistant .bubble {
-  background: #e0e0e0;
-  color: #222;
-  border-bottom-left-radius: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  white-space: pre-wrap;
+  line-height: 1.8em;
 }
 
-.input-area {
-  display: flex;
-  border-top: 1px solid #ddd;
+.message.user {
+  background-color: #2e2e2e;
+  align-self: flex-end;
 }
-.input-area input {
-  flex: 1;
-  padding: 0.75rem;
-  border: none;
-  font-size: 1rem;
+
+.message.assistant {
+  padding: 0;
+  background-color: transparent;
+  align-self: flex-start;
+  white-space: pre-wrap;
+  text-align: justify;
 }
-.input-area button {
-  padding: 0 1rem;
-  border: none;
-  background: #007bff;
-  color: white;
-  font-size: 1rem;
-}
-.typing {
+
+.thinking {
   font-style: italic;
-  opacity: 0.6;
+  opacity: 0.8;
 }
-.blink {
+
+.thinking::after {
+  content: '';
   display: inline-block;
-  width: 1ch;
-  animation: blink 1s steps(1) infinite;
+  width: 8px;
+  height: 8px;
+  margin-left: 5px;
+  border-radius: 50%;
+  background: #999;
+  animation: blink 1s infinite;
 }
+
+#input-form {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1rem;
+  background-color: #1e1e1e;
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+#input-container {
+  display: flex;
+  align-items: center;
+  max-width: 700px;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background-color: #2a2a2a;
+  border-radius: 1rem;
+  border: 1px solid #3a3a3a;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+#input-container input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: #e0e0e0;
+  outline: none;
+}
+
+#send-button {
+  margin-left: 0.5rem;
+  background: none;
+  border: none;
+  width: 2.2rem;
+  height: 2.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  cursor: pointer;
+  color: black;
+  background-color: white;
+}
+
+#send-button:hover {
+  opacity: 0.7;
+}
+
+#stop-button {
+  margin-left: 0.5rem;
+  padding: 0 1rem;
+  background-color: transparent;
+  border: 1px solid #ff5555;
+  color: #ff5555;
+  display: none;
+  border-radius: 4px;
+}
+
+#stop-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 @keyframes blink {
+  0% { opacity: 1; }
   50% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+.cursor {
+  display: inline-block;
+  width: 1px;
+  background-color: #e0e0e0;
+  margin-left: 2px;
+  animation: blink 1s step-end infinite;
 }


### PR DESCRIPTION
## Summary
- use previous CSS for the chat layout
- adjust `Chat` component markup to match old DOM structure
- simplify `Message` component to remove bubble wrapper

## Testing
- `npm run lint` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6854b4a0650c832c8b7543d4dacea3c2